### PR TITLE
fix: remove accidentally remained println debug

### DIFF
--- a/src/rust.rs
+++ b/src/rust.rs
@@ -674,7 +674,6 @@ impl<'opt> CodeEdit<'opt> {
             self.force_apply()?;
 
             let code_lines = &self.string.split('\n').collect::<Vec<_>>();
-            println!("{}", &self.string);
 
             let mut output = Ok(None);
             AttributeMacroVisitor {


### PR DESCRIPTION
Fix of https://github.com/LumaKernel/cargo-glue/pull/18 https://github.com/LumaKernel/cargo-glue/pull/18#discussion_r1878410065

Resolves https://github.com/LumaKernel/cargo-glue/issues/16

Confirmed: https://atcoder.jp/contests/arc189/submissions/60639761